### PR TITLE
feat/refactor: upgrade adaptability modal window, add a new type modal window, minor changes in logic

### DIFF
--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -33,6 +33,7 @@ const Modal: FC = () => {
         recoveryPassword: () => dispatch(closeModal()),
         confirm: confirmModal,
         popup: null,
+        custom: null,
     }
 
     useEffect(() => {
@@ -83,10 +84,10 @@ const Modal: FC = () => {
                     onClick={e => e.stopPropagation()}>
 
                     <div
-                        className="flex flex-col w-[550px] h-[289px] justify-center items-center gap-8">
+                        className="flex flex-col min-w-[550px] min-h-[289px] justify-center items-center gap-8">
                         {contentMap[typeModal]}
                         <div className="text-center text-xl">{modalContent ? modalContent : modalTextMap[typeModal]}</div>
-                        {typeModal !== "popup" ? (
+                        {typeModal !== "popup" && typeModal !== "custom" ? (
                             typeModal === "errorMailExist" ? (
                                 <div className="flex gap-4">
                                     {buttonMap[typeModal].map((buttonText, index) => (

--- a/src/components/modal/modalMappings.tsx
+++ b/src/components/modal/modalMappings.tsx
@@ -5,6 +5,7 @@ export const contentMap = {
     recoveryPassword: <span className="text-4xl font-bold text-textBlack">Відновлення паролю</span>,
     confirm: <span className="text-4xl font-bold text-color5">Підтвердіть дію!</span>,
     popup: "",
+    custom: "",
 }
 export const colorType = {
     success: {
@@ -30,7 +31,11 @@ export const colorType = {
     popup: {
         background: "bg-white",
         border: "border-white",
-    }
+    },
+    custom: {
+        background: "bg-white",
+        border: "border-white",
+    },
 }
 export const buttonMap = {
     success: "Продовжити",
@@ -39,6 +44,7 @@ export const buttonMap = {
     recoveryPassword: "Відновити",
     confirm: "Ок",
     popup: "",
+    custom : "",
 }
 export const modalTextMap = {
     success: "Реєстрація пройшла успішно. Зараз ви можете налаштувати свій профіль.",
@@ -47,4 +53,5 @@ export const modalTextMap = {
     recoveryPassword: "Обліковий запис з такою поштою вже існує. Спробуйте увійти або відновити пароль.",
     confirm: undefined,
     popup: undefined,
+    custom: undefined,
 }

--- a/src/store/slices/modalSlice/initialState.ts
+++ b/src/store/slices/modalSlice/initialState.ts
@@ -1,7 +1,9 @@
+import { ReactNode } from "react";
+
 export interface ModalState {
   isModalOpen: boolean;
-  typeModal: "success" | "error" | "errorMailExist" | "recoveryPassword" | "confirm" | "popup";
-  modalContent?: string;
+  typeModal: "success" | "error" | "errorMailExist" | "recoveryPassword" | "confirm" | "popup" | "custom";
+  modalContent?: string | ReactNode;
   onCallFunction?: () => void;
 }
 

--- a/src/store/slices/modalSlice/modalSlice.ts
+++ b/src/store/slices/modalSlice/modalSlice.ts
@@ -1,9 +1,10 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { initialState } from "./initialState";
+import { ReactNode } from "react";
 
 type modalPayload =
-  | { typeModal: "success" | "error" | "errorMailExist" | "recoveryPassword" | "popup"; modalContent?: string; onCallFunction?: () => void }
-  | { typeModal: "confirm"; modalContent?: string; onCallFunction: () => void };
+  | { typeModal: "success" | "error" | "errorMailExist" | "recoveryPassword" | "popup" | "custom"; modalContent?: string | ReactNode; onCallFunction?: () => void }
+  | { typeModal: "confirm"; modalContent?: string | ReactNode; onCallFunction: () => void };
 
 
 const modalSlice = createSlice({

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -38,9 +38,9 @@ export const store = configureStore({
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({
       serializableCheck: {
-        ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
-        ignoredActionPaths: ['payload.onCallFunction'],
-        ignoredPaths: ['modal.onCallFunction'],
+        ignoredActions: ['modal/openModal', 'modal/closeModal', FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
+        ignoredActionPaths: ['payload.modalContent'],
+        ignoredPaths: ['modal.modalContent', 'modal.onCallFunction'],
       },
     }),
 });


### PR DESCRIPTION
- New type modal: **_custom_**, for “clean template” for flexible creation of your own content in modal.

- **Added ability** to drop not only text, but also components into the modal window.

- **Added flexibility** of the modal window, it will try to adjust to the size of the content that will be thrown to it