### PR TITLE
feat/refactor: fixed passing of components to modal window, small code refactoring, added possibility to change color of modal code when it is called

### DIFF
--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -11,14 +11,15 @@ import Icon from "../Icon/Icon.tsx";
 
 // Alex
 import { useNavigate } from "react-router-dom";
-import { useTranslation } from "react-i18next";
 
 const Modal: FC = () => {
 
     const dispatch = useAppDispatch();
-    const { isModalOpen, modalContent, onCallFunction, typeModal } = useAppSelector(
+    const { isModalOpen, modalContent, onCallFunction, typeModal, colorModal } = useAppSelector(
         (state) => state.modal,
     );
+    const bgColor: string | undefined = colorModal;
+    const borderColor: string | undefined = colorModal;
 
     const confirmModal = (): void => {
         onCallFunction?.();
@@ -61,16 +62,14 @@ const Modal: FC = () => {
         if (typeModal === "popup") {
             timerModalPopup = setTimeout(() => {
                 dispatch(closeModal());
-            // TODO: 3000 -> 10000
             }, 10000);
         };
         return () => clearTimeout(timerModalPopup);
-        
+
     }, [typeModal, dispatch]);
-    
+
     //Alex
     const navigate = useNavigate();
-    const {t} = useTranslation();
 
 
     if (!isModalOpen) return null;
@@ -84,19 +83,24 @@ const Modal: FC = () => {
             <div>
                 <div className={clsx(
                     "relative top-1 w-[130px] h-[30px] rounded-tr-xl z-30 rounded-tl-xl",
-                    colorType[typeModal]?.background
+                    colorModal?.length > 1
+                        ? `bg-${bgColor}`
+                        : colorType[typeModal]?.background
                 )}>
                 </div>
                 <div
                     className={clsx(
                         "flex flex-row justify-between items-start p-4 w-auto h-auto z-40 bg-white rounded-lg rounded-tl-none shadow-form_shadow border-4",
-                        colorType[typeModal]?.border)}
+                        colorModal?.length > 1
+                            ? `border-${borderColor}`
+                            : colorType[typeModal]?.border
+                    )}
                     onClick={e => e.stopPropagation()}>
 
                     <div
                         className="flex flex-col min-w-[550px] min-h-[289px] justify-center items-center gap-8">
                         {contentMap[typeModal]}
-                        <div className="text-center text-xl">{modalContent ? t(`${modalContent}`) : modalTextMap[typeModal]}</div>
+                        <div className="text-center text-xl">{modalContent ? modalContent : modalTextMap[typeModal]}</div>
                         {typeModal !== "popup" && typeModal !== "custom" ? (
                             typeModal === "errorMailExist" ? (
                                 <div className="flex gap-4">
@@ -110,8 +114,8 @@ const Modal: FC = () => {
                                                 index === 0
                                                     // ? () => {console.log("Увійти натиснуто"); functionButtonMap[typeModal]()}
                                                     // : () => {console.log("Відновити натиснуто"); functionButtonMap[typeModal]()}
-                                                    ? () => {console.log("Увійти натиснуто"); functionButtonMap[typeModal](); navigate("log-in")}
-                                                    : () => {console.log("Відновити натиснуто"); functionButtonMap[typeModal](); dispatch(openModal({typeModal:"popup"}))}
+                                                    ? () => { console.log("Увійти натиснуто"); functionButtonMap[typeModal](); navigate("log-in") }
+                                                    : () => { console.log("Відновити натиснуто"); functionButtonMap[typeModal](); dispatch(openModal({ typeModal: "custom" })) }
                                             }
                                         >
                                             {buttonText}
@@ -134,7 +138,7 @@ const Modal: FC = () => {
                     <button
                         onClick={() => dispatch(closeModal())}
                         className="rounded-md hover:bg-color2">
-                        <Icon id="close" className="w-6 h-6 fill-textBlack"/>
+                        <Icon id="close" className="w-6 h-6 fill-textBlack" />
                     </button>
 
                 </div>

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -18,8 +18,8 @@ const Modal: FC = () => {
     const { isModalOpen, modalContent, onCallFunction, typeModal, colorModal } = useAppSelector(
         (state) => state.modal,
     );
-    const bgColor: string | undefined = colorModal;
-    const borderColor: string | undefined = colorModal;
+    const bgColor = colorModal;
+    const borderColor = colorModal;
 
     const confirmModal = (): void => {
         onCallFunction?.();
@@ -83,7 +83,7 @@ const Modal: FC = () => {
             <div>
                 <div className={clsx(
                     "relative top-1 w-[130px] h-[30px] rounded-tr-xl z-30 rounded-tl-xl",
-                    colorModal?.length > 1
+                    (colorModal && colorModal?.length > 1)
                         ? `bg-${bgColor}`
                         : colorType[typeModal]?.background
                 )}>
@@ -91,7 +91,7 @@ const Modal: FC = () => {
                 <div
                     className={clsx(
                         "flex flex-row justify-between items-start p-4 w-auto h-auto z-40 bg-white rounded-lg rounded-tl-none shadow-form_shadow border-4",
-                        colorModal?.length > 1
+                        (colorModal && colorModal?.length > 1)
                             ? `border-${borderColor}`
                             : colorType[typeModal]?.border
                     )}

--- a/src/components/modal/modalMappings.tsx
+++ b/src/components/modal/modalMappings.tsx
@@ -1,13 +1,11 @@
-import { ForgotPassword } from "../../pages/ForgotPassword"
 export const contentMap = {
     success: <span className="text-4xl font-bold text-color8">Успіх!</span>,
     error: <span className="text-4xl font-bold text-color2">Упс!</span>,
+    confirm: <span className="text-4xl font-bold text-color5">Підтвердіть дію!</span>,
+    popup: "",
+    custom: "",
     errorMailExist: <span className="text-4xl font-bold text-color2">Упс!</span>,
     recoveryPassword: <span className="text-4xl font-bold text-textBlack">Відновлення паролю</span>,
-    confirm: <span className="text-4xl font-bold text-color5">Підтвердіть дію!</span>,
-    // popup: "",
-    popup: <ForgotPassword/>,
-    custom: "",
 }
 export const colorType = {
     success: {
@@ -18,6 +16,18 @@ export const colorType = {
         background: "bg-color2",
         border: "border-color2",
     },
+    confirm: {
+        background: "bg-color8",
+        border: "border-color8",
+    },
+    popup: {
+        background: "bg-white",
+        border: "border-white",
+    },
+    custom: {
+        background: "bg-white",
+        border: "border-white",
+    },
     errorMailExist: {
         background: "bg-color2",
         border: "border-color2",
@@ -26,36 +36,22 @@ export const colorType = {
         background: "bg-button",
         border: "border-button",
     },
-    confirm: {
-        background: "bg-color8",
-        border: "border-color8",
-    },
-    popup: {
-        // background: "bg-white",
-        // border: "border-white",
-        background: "bg-button",
-        border: "border-button",
-    },
-    custom: {
-        background: "bg-white",
-        border: "border-white",
-    },
 }
 export const buttonMap = {
     success: "Продовжити",
     error: "Повторити спробу",
-    errorMailExist: ["Увійти", "Відновити"],
-    recoveryPassword: "Відновити",
     confirm: "Ок",
     popup: "",
     custom : "",
+    errorMailExist: ["Увійти", "Відновити"],
+    recoveryPassword: "Відновити",
 }
 export const modalTextMap = {
     success: "Реєстрація пройшла успішно. Зараз ви можете налаштувати свій профіль.",
     error: "Перевірте введені дані та спробуйте ще раз.",
-    errorMailExist: "Обліковий запис з такою поштою вже існує. Спробуйте увійти або відновити пароль.",
-    recoveryPassword: "Обліковий запис з такою поштою вже існує. Спробуйте увійти або відновити пароль.",
     confirm: undefined,
     popup: undefined,
     custom: undefined,
+    errorMailExist: "Обліковий запис з такою поштою вже існує. Спробуйте увійти або відновити пароль.",
+    recoveryPassword: "Обліковий запис з такою поштою вже існує. Спробуйте увійти або відновити пароль.",
 }

--- a/src/layouts/AuthorizationLayout.tsx
+++ b/src/layouts/AuthorizationLayout.tsx
@@ -10,6 +10,7 @@ import Checkbox from "../components/checkbox/Checkbox";
 import { Button } from "../components/buttons/Button/Button";
 import Separator from "../components/separator/Separator";
 import Footer from "../components/layout/Footer";
+import { ForgotPassword } from "../pages/ForgotPassword";
 
 import { useAppSelector, useAppDispatch } from "../store/hook";
 import { useTranslation } from "react-i18next";
@@ -101,7 +102,9 @@ const AuthorizationLayout = ({ type }: AuthorizationLayoutProps) => {
                         onClick={() =>
                           dispatch(
                             openModal({
-                              typeModal: "popup",
+                              typeModal: "custom",
+                              modalContent: <ForgotPassword/>,
+                              colorModal: "button"
                             })
                           )
                         }

--- a/src/store/slices/modalSlice/initialState.ts
+++ b/src/store/slices/modalSlice/initialState.ts
@@ -5,7 +5,7 @@ export interface ModalState {
   typeModal: "success" | "error" | "errorMailExist" | "recoveryPassword" | "confirm" | "popup" | "custom";
   modalContent?: string | ReactNode;
   onCallFunction?: () => void;
-  colorModal?: string | undefined;
+  colorModal?: string;
 }
 
 export const initialState: ModalState = {

--- a/src/store/slices/modalSlice/initialState.ts
+++ b/src/store/slices/modalSlice/initialState.ts
@@ -5,6 +5,7 @@ export interface ModalState {
   typeModal: "success" | "error" | "errorMailExist" | "recoveryPassword" | "confirm" | "popup" | "custom";
   modalContent?: string | ReactNode;
   onCallFunction?: () => void;
+  colorModal?: string | undefined;
 }
 
 export const initialState: ModalState = {
@@ -12,4 +13,5 @@ export const initialState: ModalState = {
   typeModal: "success",
   modalContent: undefined,
   onCallFunction: undefined,
+  colorModal: "",
 };

--- a/src/store/slices/modalSlice/modalSlice.ts
+++ b/src/store/slices/modalSlice/modalSlice.ts
@@ -3,7 +3,7 @@ import { initialState } from "./initialState";
 import { ReactNode } from "react";
 
 type modalPayload =
-  | { typeModal: "success" | "error" | "errorMailExist" | "recoveryPassword" | "popup"; modalContent?: string | ReactNode; onCallFunction?: () => void }
+  | { typeModal: "success" | "error" | "errorMailExist" | "recoveryPassword" | "popup" | "custom"; modalContent?: string | ReactNode; onCallFunction?: () => void; colorModal?: string | undefined }
   | { typeModal: "confirm"; modalContent?: string | ReactNode; onCallFunction: () => void };
 
 
@@ -16,12 +16,14 @@ const modalSlice = createSlice({
       state.modalContent = action.payload.modalContent;
       state.onCallFunction = action.payload.onCallFunction;
       state.typeModal = action.payload.typeModal;
+      state.colorModal = action.payload.colorModal;
     },
     closeModal: (state) => {
       state.isModalOpen = false;
       state.modalContent = undefined;
       state.onCallFunction = undefined;
       state.typeModal = "success";
+      state.colorModal = "";
     },
   },
 });

--- a/src/store/slices/modalSlice/modalSlice.ts
+++ b/src/store/slices/modalSlice/modalSlice.ts
@@ -3,8 +3,8 @@ import { initialState } from "./initialState";
 import { ReactNode } from "react";
 
 type modalPayload =
-  | { typeModal: "success" | "error" | "errorMailExist" | "recoveryPassword" | "popup" | "custom"; modalContent?: string | ReactNode; onCallFunction?: () => void; colorModal?: string | undefined }
-  | { typeModal: "confirm"; modalContent?: string | ReactNode; onCallFunction: () => void };
+  | { typeModal: "success" | "error" | "errorMailExist" | "recoveryPassword" | "popup" | "custom"; modalContent?: string | ReactNode; onCallFunction?: () => void; colorModal?: string }
+  | { typeModal: "confirm"; modalContent?: string | ReactNode; onCallFunction: () => void; colorModal?: string };
 
 
 const modalSlice = createSlice({

--- a/src/store/slices/modalSlice/selectors.ts
+++ b/src/store/slices/modalSlice/selectors.ts
@@ -4,3 +4,4 @@ export const isOpenModal = (state:RootState) => state.modal.isModalOpen;
 export const modalContent = (state:RootState) => state.modal.modalContent;
 export const modalCallFunction = (state:RootState) => state.modal.onCallFunction;
 export const typeModal = (state:RootState) => state.modal.typeModal;
+export const colorModal = (state:RootState) => state.modal.colorModal;


### PR DESCRIPTION
- New property **colorModal**, when calling a modal window through the dispatcher you can pass the color.

- Very little changes in the code structure
 
- Now passing a component inside a modal window works correctly, without errors.